### PR TITLE
Fix Bingo types

### DIFF
--- a/data/bingo/general_extra.txt
+++ b/data/bingo/general_extra.txt
@@ -20,7 +20,7 @@ def has_substructure(
         SQLAlchemy expression for substructure matching that can be used in WHERE clauses.
     
     """
-    return mol.op("@")(text(f"('{query}', '{parameters}')::bingo.sub"))
+    return mol.op("@")(tuple_(query, parameters).cast(_BingoSearchType("bingo.sub")))
 
 
 def matches_smarts(
@@ -44,7 +44,7 @@ def matches_smarts(
         SQLAlchemy expression for SMARTS matching that can be used in WHERE clauses.
 
     """
-    return mol.op("@")(text(f"('{query}', '{parameters}')::bingo.smarts"))
+    return mol.op("@")(tuple_(query, parameters).cast(_BingoSearchType("bingo.smarts")))
 
 
 def mol_equals(mol: ColumnElement[AnyBingoMol], query: TextLike, parameters: TextLike = ""):
@@ -67,7 +67,7 @@ def mol_equals(mol: ColumnElement[AnyBingoMol], query: TextLike, parameters: Tex
         SQLAlchemy expression for exact matching that can be used in WHERE clauses.
 
     """
-    return mol.op("@")(text(f"('{query}', '{parameters}')::bingo.exact"))
+    return mol.op("@")(tuple_(query, parameters).cast(_BingoSearchType("bingo.exact")))
 
 
 def similarity(
@@ -101,6 +101,6 @@ def similarity(
         SQLAlchemy expression for similarity matching that can be used in WHERE clauses.
 
     """
-    return mol.op("%")(
-        text(f"('{query}', {bottom}, {top}, '{metric}')::bingo.sim")
+    return mol.op("@")(
+        tuple_(bottom, top, query, metric).cast(_BingoSearchType("bingo.sim"))
     )

--- a/data/bingo/general_header.txt
+++ b/data/bingo/general_header.txt
@@ -3,20 +3,21 @@ This file defines public Bingo PostgreSQL function wrappers for use with SQLAlch
 """
 
 
-from sqlalchemy import types as sqltypes
-from sqlalchemy.sql import text
-from sqlalchemy.sql.elements import BinaryExpression
-from sqlalchemy.sql.elements import ColumnElement
-from sqlalchemy.sql.functions import GenericFunction
 from typing import Any, Literal
+
+from sqlalchemy import tuple_
+from sqlalchemy import types as sqltypes
+from sqlalchemy.sql.elements import BinaryExpression, ColumnElement
+from sqlalchemy.sql.functions import GenericFunction
+
 from ._types import (
-    TextLike,
     AnyBingoBinaryMolLike,
     AnyBingoBinaryReactionLike,
     AnyBingoMolLike,
     AnyBingoMolLikeCombined,
     AnyBingoReactionLike,
     AnyBingoReactionLikeCombined,
+    TextLike,
 )
 
 # Backward compatibility aliases
@@ -24,3 +25,13 @@ AnyBingoMol = AnyBingoMolLikeCombined
 AnyBingoReaction = AnyBingoReactionLikeCombined
 
 
+class _BingoSearchType(sqltypes.UserDefinedType):
+    """SQLAlchemy type wrapper for casting search tuples to Bingo composite types."""
+
+    cache_ok = True
+
+    def __init__(self, type_name: str) -> None:
+        self.type_name = type_name
+
+    def get_col_spec(self, **kw: Any) -> str:
+        return self.type_name

--- a/src/molalchemy/bingo/functions/general.py
+++ b/src/molalchemy/bingo/functions/general.py
@@ -4,8 +4,8 @@ This file defines public Bingo PostgreSQL function wrappers for use with SQLAlch
 
 from typing import Any, Literal
 
+from sqlalchemy import tuple_
 from sqlalchemy import types as sqltypes
-from sqlalchemy.sql import text
 from sqlalchemy.sql.elements import BinaryExpression, ColumnElement
 from sqlalchemy.sql.functions import GenericFunction
 
@@ -22,6 +22,18 @@ from ._types import (
 # Backward compatibility aliases
 AnyBingoMol = AnyBingoMolLikeCombined
 AnyBingoReaction = AnyBingoReactionLikeCombined
+
+
+class _BingoSearchType(sqltypes.UserDefinedType):
+    """SQLAlchemy type wrapper for casting search tuples to Bingo composite types."""
+
+    cache_ok = True
+
+    def __init__(self, type_name: str) -> None:
+        self.type_name = type_name
+
+    def get_col_spec(self, **kw: Any) -> str:
+        return self.type_name
 
 
 def has_substructure(
@@ -46,7 +58,7 @@ def has_substructure(
         SQLAlchemy expression for substructure matching that can be used in WHERE clauses.
 
     """
-    return mol.op("@")(text(f"('{query}', '{parameters}')::bingo.sub"))
+    return mol.op("@")(tuple_(query, parameters).cast(_BingoSearchType("bingo.sub")))
 
 
 def matches_smarts(
@@ -70,7 +82,7 @@ def matches_smarts(
         SQLAlchemy expression for SMARTS matching that can be used in WHERE clauses.
 
     """
-    return mol.op("@")(text(f"('{query}', '{parameters}')::bingo.smarts"))
+    return mol.op("@")(tuple_(query, parameters).cast(_BingoSearchType("bingo.smarts")))
 
 
 def mol_equals(
@@ -95,7 +107,7 @@ def mol_equals(
         SQLAlchemy expression for exact matching that can be used in WHERE clauses.
 
     """
-    return mol.op("@")(text(f"('{query}', '{parameters}')::bingo.exact"))
+    return mol.op("@")(tuple_(query, parameters).cast(_BingoSearchType("bingo.exact")))
 
 
 def similarity(
@@ -129,7 +141,9 @@ def similarity(
         SQLAlchemy expression for similarity matching that can be used in WHERE clauses.
 
     """
-    return mol.op("%")(text(f"('{query}', {bottom}, {top}, '{metric}')::bingo.sim"))
+    return mol.op("@")(
+        tuple_(bottom, top, query, metric).cast(_BingoSearchType("bingo.sim"))
+    )
 
 
 class aam(GenericFunction):

--- a/src/molalchemy/bingo/types.py
+++ b/src/molalchemy/bingo/types.py
@@ -231,6 +231,15 @@ class BingoBinaryReaction(BingoBaseType):
     format in PostgreSQL. It provides storage efficiency and fast comparison
     operations for reaction data.
 
+    Parameters
+    ----------
+    preserve_pos : bool, default False
+        Whether to preserve atom coordinates when converting to binary format.
+        If `True`, coordinates are stored; if `False`, they are discarded.
+
+    Warnings
+    --------
+    When `preserve_pos=True`, only inputs with present atomic coordinates should be used, otherwise conversion can return `NULL`.
 
     Examples
     --------
@@ -269,8 +278,17 @@ class BingoBinaryReaction(BingoBaseType):
     cache_ok = True
     comparator_factory = BingoRxnComparator
 
+    def __init__(self, preserve_pos: bool = False):
+        self.preserve_pos = preserve_pos
+        super().__init__()
+
     def __repr__(self):
+        if self.preserve_pos:
+            return "BingoBinaryReaction(preserve_pos=True)"
         return "BingoBinaryReaction()"
 
     def get_col_spec(self, **kwargs: Any) -> str:
         return "bytea"
+
+    def bind_expression(self, bindvalue):
+        return func.Bingo.CompactReaction(bindvalue, self.preserve_pos)

--- a/tests/bingo/test_functions.py
+++ b/tests/bingo/test_functions.py
@@ -5,7 +5,14 @@ from sqlalchemy import (
     BinaryExpression,
     Column,
     Function,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    bindparam,
+    select,
 )
+from sqlalchemy.dialects import postgresql
 
 from molalchemy.bingo import functions as bingo_func
 from molalchemy.bingo.types import BingoMol
@@ -25,3 +32,78 @@ def test_any_function_returns_function_object(func):
         except AttributeError:
             result = func(*random_columns[: func.__code__.co_argcount])
             assert isinstance(result, BinaryExpression)
+
+
+def test_bingo_search_helpers_bind_literal_inputs():
+    """Search helper literals must compile as bind parameters, not SQL text."""
+    compounds = Table(
+        "compounds",
+        MetaData(),
+        Column("id", Integer),
+        Column("structure", BingoMol()),
+    )
+    injected_query = "x' OR 1=1 --"
+
+    stmt = select(compounds).where(
+        bingo_func.has_substructure(compounds.c.structure, injected_query)
+    )
+
+    compiled = stmt.compile(dialect=postgresql.dialect())
+    sql = str(compiled)
+
+    assert injected_query not in sql
+    assert "bingo.sub" in sql
+    assert "CAST" in sql
+    assert injected_query in compiled.params.values()
+
+
+def test_bingo_search_helpers_preserve_bindparam_inputs():
+    """Explicit bind parameters should remain bind parameters in generated SQL."""
+    compounds = Table(
+        "compounds",
+        MetaData(),
+        Column("id", Integer),
+        Column("structure", BingoMol()),
+    )
+
+    stmt = select(compounds).where(
+        bingo_func.mol_equals(compounds.c.structure, bindparam("query_mol"))
+    )
+
+    compiled = stmt.compile(dialect=postgresql.dialect())
+    sql = str(compiled)
+
+    assert "%(query_mol)s" in sql
+    assert "':query_mol'" not in sql
+    assert "bingo.exact" in sql
+
+
+def test_bingo_similarity_preserves_column_expression_inputs():
+    """Column expressions should compile as columns, not stringified values."""
+    compounds = Table(
+        "compounds",
+        MetaData(),
+        Column("id", Integer),
+        Column("structure", BingoMol()),
+        Column("query_structure", String),
+    )
+
+    stmt = select(compounds).where(
+        bingo_func.similarity(
+            compounds.c.structure,
+            compounds.c.query_structure,
+            0.2,
+            0.9,
+            "Dice",
+        )
+    )
+
+    compiled = stmt.compile(
+        dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+    )
+    sql = str(compiled)
+
+    assert "0.2, 0.9, compounds.query_structure" in sql
+    assert "'compounds.query_structure'" not in sql
+    assert " @ " in sql
+    assert "bingo.sim" in sql

--- a/tests/bingo/test_types.py
+++ b/tests/bingo/test_types.py
@@ -2,9 +2,15 @@
 
 import pytest
 from sqlalchemy import Column, Integer, MetaData, String, Table
+from sqlalchemy.dialects import postgresql
 
-from molalchemy.bingo.comparators import BingoMolComparator
-from molalchemy.bingo.types import BingoBinaryMol, BingoMol
+from molalchemy.bingo.comparators import BingoMolComparator, BingoRxnComparator
+from molalchemy.bingo.types import (
+    BingoBinaryMol,
+    BingoBinaryReaction,
+    BingoMol,
+    BingoReaction,
+)
 
 
 class TestBingoMol:
@@ -91,6 +97,97 @@ class TestBingoBinaryMol:
         assert str(expr) == expected_sql
 
 
+class TestBingoReaction:
+    """Test BingoReaction type."""
+
+    def test_bingo_reaction_cache_ok(self):
+        """Test that BingoReaction has cache_ok=True."""
+        bingo_reaction = BingoReaction()
+        assert bingo_reaction.cache_ok is True
+
+    def test_bingo_reaction_col_spec(self):
+        """Test that BingoReaction returns correct column specification."""
+        bingo_reaction = BingoReaction()
+        assert bingo_reaction.get_col_spec() == "varchar"
+
+    def test_bingo_reaction_comparator_factory(self):
+        """Test that BingoReaction uses BingoRxnComparator."""
+        bingo_reaction = BingoReaction()
+        assert bingo_reaction.comparator_factory == BingoRxnComparator
+
+    def test_bingo_reaction_in_table_definition(self):
+        """Test BingoReaction can be used in table definition."""
+        metadata = MetaData()
+        test_table = Table(
+            "test_reactions",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("name", String(100)),
+            Column("rxn", BingoReaction()),
+        )
+
+        assert test_table.c.rxn.type.__class__ == BingoReaction
+        assert isinstance(test_table.c.rxn.type, BingoReaction)
+
+
+class TestBingoBinaryReaction:
+    """Test BingoBinaryReaction type."""
+
+    def test_bingo_binary_reaction_cache_ok(self):
+        """Test that BingoBinaryReaction has cache_ok=True."""
+        bingo_binary_reaction = BingoBinaryReaction()
+        assert bingo_binary_reaction.cache_ok is True
+
+    def test_bingo_binary_reaction_col_spec(self):
+        """Test that BingoBinaryReaction returns correct column specification."""
+        bingo_binary_reaction = BingoBinaryReaction()
+        assert bingo_binary_reaction.get_col_spec() == "bytea"
+
+    def test_bingo_binary_reaction_comparator_factory(self):
+        """Test that BingoBinaryReaction uses BingoRxnComparator."""
+        bingo_binary_reaction = BingoBinaryReaction()
+        assert bingo_binary_reaction.comparator_factory == BingoRxnComparator
+
+    def test_bingo_binary_reaction_in_table_definition(self):
+        """Test BingoBinaryReaction can be used in table definition."""
+        metadata = MetaData()
+        test_table = Table(
+            "test_binary_reactions",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("name", String(100)),
+            Column("rxn", BingoBinaryReaction()),
+        )
+
+        assert test_table.c.rxn.type.__class__ == BingoBinaryReaction
+        assert isinstance(test_table.c.rxn.type, BingoBinaryReaction)
+
+    @pytest.mark.parametrize(
+        "preserve_pos",
+        [
+            False,
+            True,
+        ],
+    )
+    def test_insert_uses_compact_reaction(self, preserve_pos):
+        """Test inserts convert reaction text to Bingo binary reaction data."""
+        metadata = MetaData()
+        test_table = Table(
+            "test_binary_reactions",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("rxn", BingoBinaryReaction(preserve_pos=preserve_pos)),
+        )
+
+        stmt = test_table.insert().values(id=1, rxn="CCO>>CC=O")
+        compiled_statement = stmt.compile(dialect=postgresql.dialect())
+        compiled = str(compiled_statement)
+
+        assert "Bingo.CompactReaction" in compiled
+        assert compiled_statement.params["rxn"] == "CCO>>CC=O"
+        assert preserve_pos in compiled_statement.params.values()
+
+
 class TestTypesIntegration:
     """Integration tests for bingo types."""
 
@@ -109,3 +206,22 @@ class TestTypesIntegration:
 
         assert bingo_mol.cache_ok is True
         assert bingo_binary_mol.cache_ok is True
+
+    def test_reaction_types_have_same_comparator(self):
+        """Test that both reaction types use the same comparator."""
+        bingo_reaction = BingoReaction()
+        bingo_binary_reaction = BingoBinaryReaction()
+
+        assert (
+            bingo_reaction.comparator_factory
+            == bingo_binary_reaction.comparator_factory
+        )
+        assert bingo_reaction.comparator_factory == BingoRxnComparator
+
+    def test_reaction_types_are_cache_ok(self):
+        """Test that both reaction types have cache_ok=True."""
+        bingo_reaction = BingoReaction()
+        bingo_binary_reaction = BingoBinaryReaction()
+
+        assert bingo_reaction.cache_ok is True
+        assert bingo_binary_reaction.cache_ok is True


### PR DESCRIPTION
 ## Summary
  - Add insert-time `Bingo.CompactReaction(...)` conversion for `BingoBinaryReaction`
  - Add `preserve_pos` support and documentation for binary reaction compaction
  - Fix the possible injection surfaces in the bingo types